### PR TITLE
Experimental run config implementation 

### DIFF
--- a/bsp/resources/META-INF/BSP.xml
+++ b/bsp/resources/META-INF/BSP.xml
@@ -46,7 +46,8 @@
         <!--<postStartupActivity implementation="org.jetbrains.bsp.BspStartupActivity"/>-->
         <applicationInitializedListener implementation="org.jetbrains.bsp.StartupRoutine"/>
 
-        <runLineMarkerContributor implementationClass="org.jetbrains.bsp.project.BspTestRunLineMarkerProvider" language="Scala"/>
+        <runLineMarkerContributor implementationClass="org.jetbrains.bsp.project.test.BspTestRunLineMarkerProvider" language="Scala"/>
+        <configurationType implementation="org.jetbrains.bsp.project.test.BspTestRunType"/>
 
     </extensions>
 

--- a/bsp/src/org/jetbrains/bsp/project/BspProjectTaskRunner.scala
+++ b/bsp/src/org/jetbrains/bsp/project/BspProjectTaskRunner.scala
@@ -4,9 +4,12 @@ import java.io.File
 import java.util
 
 import com.intellij.compiler.impl.CompilerUtil
+import com.intellij.execution.Executor
+import com.intellij.execution.executors.DefaultRunExecutor
+import com.intellij.execution.runners.{ExecutionEnvironment, ExecutionEnvironmentBuilder}
 import com.intellij.openapi.compiler.CompilerPaths
-import com.intellij.openapi.externalSystem.model.project.{ExternalSystemSourceType, ModuleData}
-import com.intellij.openapi.externalSystem.model.{DataNode, ProjectKeys}
+import com.intellij.openapi.externalSystem.model.ProjectKeys
+import com.intellij.openapi.externalSystem.model.project.ExternalSystemSourceType
 import com.intellij.openapi.externalSystem.service.project.ProjectDataManager
 import com.intellij.openapi.externalSystem.util.{ExternalSystemApiUtil => ES}
 import com.intellij.openapi.fileEditor.FileDocumentManager
@@ -17,7 +20,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.task._
 import org.jetbrains.bsp.BSP
 import org.jetbrains.bsp.data.BspMetadata
-import org.jetbrains.bsp.settings.BspExecutionSettings
+import org.jetbrains.bsp.project.test.BspTestRunConfiguration
 import org.jetbrains.plugins.scala.extensions
 
 import scala.collection.JavaConverters._
@@ -33,7 +36,10 @@ class BspProjectTaskRunner extends ProjectTaskRunner {
         case _ : BspSyntheticModuleType => false
         case _ => ES.isExternalSystemAwareModule(BSP.ProjectSystemId, module)
       }
-    case _: ExecuteRunConfigurationTask => false // TODO support bsp run configs
+    case t: ExecuteRunConfigurationTask => t.getRunProfile match {
+      case _: BspTestRunConfiguration => true
+      case _ => false
+    }
     case _ => false
   }
 

--- a/bsp/src/org/jetbrains/bsp/project/test/BspTestRunLineMarkerProvider.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/BspTestRunLineMarkerProvider.scala
@@ -1,4 +1,4 @@
-package org.jetbrains.bsp.project
+package org.jetbrains.bsp.project.test
 
 import com.intellij.execution.lineMarker.RunLineMarkerContributor
 import com.intellij.openapi.module.ModuleManager

--- a/bsp/src/org/jetbrains/bsp/project/test/BspTestRunProfileState.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/BspTestRunProfileState.scala
@@ -5,25 +5,31 @@ import java.net.URI
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 
-import ch.epfl.scala.bsp4j
-import ch.epfl.scala.bsp4j.TestResult
+import ch.epfl.scala.bsp4j.TaskDataKind._
+import ch.epfl.scala.bsp4j.TestStatus._
+import ch.epfl.scala.bsp4j._
+import com.google.gson.{Gson, JsonObject}
 import com.intellij.execution.configurations.{RunProfileState, RunnerSettings}
-import com.intellij.execution.impl.ConsoleViewImpl
 import com.intellij.execution.process.{ProcessHandler, ProcessOutputType}
 import com.intellij.execution.runners.ProgramRunner
+import com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil
+import com.intellij.execution.testframework.sm.runner.SMTRunnerConsoleProperties
 import com.intellij.execution.{DefaultExecutionResult, ExecutionResult, Executor}
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
+import jetbrains.buildServer.messages.serviceMessages._
 import org.jetbrains.bsp.data.BspMetadata
 import org.jetbrains.bsp.protocol.BspCommunicationComponent
-import org.jetbrains.bsp.protocol.BspNotifications.BspNotification
+import org.jetbrains.bsp.protocol.BspNotifications.{BspNotification, TaskFinish, TaskStart}
 import org.jetbrains.bsp.protocol.session.BspSession.BspServer
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits._
 
+class BspTestRunProfileState(val project: Project, val rc: BspTestRunConfiguration, val ex: Executor) extends RunProfileState {
 
-class BspTestRunProfileState(val project: Project) extends RunProfileState {
+  val gson = new Gson()
 
   class MProcHandler extends ProcessHandler {
     override def destroyProcessImpl(): Unit = ()
@@ -46,26 +52,93 @@ class BspTestRunProfileState(val project: Project) extends RunProfileState {
   }
 
   private def testRequest(server: BspServer): CompletableFuture[TestResult] = {
-    val targetIds = targets().map(uri => new bsp4j.BuildTargetIdentifier(uri.toString))
-    val params = new bsp4j.TestParams(targetIds.toList.asJava)
+    val targetIds = targets().map(uri => new BuildTargetIdentifier(uri.toString))
+    val params = new TestParams(targetIds.toList.asJava)
     params.setOriginId(UUID.randomUUID().toString)
     server.buildTargetTest(params)
   }
 
-  override def execute(executor: Executor, runner: ProgramRunner[_ <: RunnerSettings]): ExecutionResult = {
-    val console = new ConsoleViewImpl(project, true)
-    val procHandler = new MProcHandler
-    console.attachToProcess(procHandler)
-    val bspCommunication = project.getComponent(classOf[BspCommunicationComponent]).communication
 
-    def notification(n: BspNotification): Unit = {
-      procHandler.notifyTextAvailable(n.toString, ProcessOutputType.STDOUT)
+  def printProc(str: MessageWithAttributes)(implicit proc: ProcessHandler): Unit = {
+    proc.notifyTextAvailable(str + System.lineSeparator(), ProcessOutputType.STDOUT)
+  }
+
+  class ServiceMsg(val name: String, val map: Map[String, String]) extends MessageWithAttributes(name, map.asJava) {
+    def this(n: String) = this(n, Map())
+  }
+
+  case class NestedBspMsg(nested: AnyRef, msg: AnyRef)
+
+  type HasNested = {
+    def getDataKind: String
+    def getData: Object
+  }
+
+  private def extractNestedMessage(bspMessage: AnyRef): AnyRef = bspMessage match {
+    case x: HasNested@unchecked =>
+      val kind = x.getDataKind
+      val rawNested = x.getData
+      rawNested match {
+        case d: JsonObject => kind match {
+          case TEST_FINISH => gson.fromJson(d, classOf[TestFinish])
+          case TEST_TASK => gson.fromJson(d, classOf[TestTask])
+          case TEST_REPORT => gson.fromJson(d, classOf[TestReport])
+          case TEST_START => gson.fromJson(d, classOf[TestStart])
+          case _ => rawNested
+        }
+        case _ => rawNested
+      }
+    case x => x
+  }
+
+  class BspTestSession {
+    val startTime: mutable.Map[String, Long] = mutable.Map()
+  }
+
+  // TODO handle standard output of test cases
+  private def onBspNotification(proc: ProcessHandler, session: BspTestSession)(n: BspNotification): Unit = {
+    implicit val pr = proc
+    n match {
+      case TaskStart(params) => extractNestedMessage(params) match {
+        case t: TestTask =>
+          printProc(new ServiceMsg("enteredTheMatrix"))
+          printProc(new TestSuiteStarted("BSP"))
+        case t: TestStart =>
+          printProc(new TestStarted(t.getDisplayName, false, null))
+          session.startTime += (t.getDisplayName -> params.getEventTime)
+        case _ =>
+      }
+      case TaskFinish(params) => extractNestedMessage(params) match {
+        case t: TestReport => printProc(new TestSuiteFinished("BSP"))
+        case t: TestFinish =>
+          t.getStatus match {
+            case PASSED =>
+            case FAILED => printProc(new ServiceMsg("testFailed", Map("name" -> t.getDisplayName, "message" -> t.getMessage)))
+            case _ => printProc(new TestIgnored(t.getDisplayName, "Ignored"))
+          }
+          printProc(new TestFinished(t.getDisplayName, session.startTime.get(t.getDisplayName)
+            .map { st =>
+              session.startTime -= t.getDisplayName
+              (params.getEventTime - st).intValue()
+            }.getOrElse(0)))
+        case _ =>
+      }
+      case _ =>
     }
 
-    bspCommunication.run(testRequest, notification, procHandler.notifyTextAvailable(_, ProcessOutputType.STDOUT))
+  }
+
+
+  override def execute(executor: Executor, runner: ProgramRunner[_ <: RunnerSettings]): ExecutionResult = {
+    val procHandler = new MProcHandler
+    val console = SMTestRunnerConnectionUtil.createAndAttachConsole("BSP", procHandler, new SMTRunnerConsoleProperties(
+      project, rc, "BSP", ex))
+    val bspCommunication = project.getComponent(classOf[BspCommunicationComponent]).communication
+
+    bspCommunication.run(testRequest, onBspNotification(procHandler, new BspTestSession()), _ => {
+    })
       .future
       .onComplete(_ => procHandler.shutdown())
-
     new DefaultExecutionResult(console, procHandler)
   }
 

--- a/bsp/src/org/jetbrains/bsp/project/test/BspTestRunProfileState.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/BspTestRunProfileState.scala
@@ -1,0 +1,72 @@
+package org.jetbrains.bsp.project.test
+
+import java.io.OutputStream
+import java.net.URI
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+
+import ch.epfl.scala.bsp4j
+import ch.epfl.scala.bsp4j.TestResult
+import com.intellij.execution.configurations.{RunProfileState, RunnerSettings}
+import com.intellij.execution.impl.ConsoleViewImpl
+import com.intellij.execution.process.{ProcessHandler, ProcessOutputType}
+import com.intellij.execution.runners.ProgramRunner
+import com.intellij.execution.{DefaultExecutionResult, ExecutionResult, Executor}
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
+import org.jetbrains.bsp.data.BspMetadata
+import org.jetbrains.bsp.protocol.BspCommunicationComponent
+import org.jetbrains.bsp.protocol.BspNotifications.BspNotification
+import org.jetbrains.bsp.protocol.session.BspSession.BspServer
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext.Implicits._
+
+
+class BspTestRunProfileState(val project: Project) extends RunProfileState {
+
+  class MProcHandler extends ProcessHandler {
+    override def destroyProcessImpl(): Unit = ()
+
+    override def detachProcessImpl(): Unit = {}
+
+    override def detachIsDefault(): Boolean = false
+
+    override def getProcessInput: OutputStream = null
+
+    def shutdown(): Unit = {
+      super.notifyProcessTerminated(0)
+    }
+  }
+
+  private def targets(): List[URI] = {
+    ModuleManager.getInstance(project).getModules.toList
+      .flatMap(BspMetadata.get(project, _))
+      .flatMap(x => x.targetIds.asScala.toList)
+  }
+
+  private def testRequest(server: BspServer): CompletableFuture[TestResult] = {
+    val targetIds = targets().map(uri => new bsp4j.BuildTargetIdentifier(uri.toString))
+    val params = new bsp4j.TestParams(targetIds.toList.asJava)
+    params.setOriginId(UUID.randomUUID().toString)
+    server.buildTargetTest(params)
+  }
+
+  override def execute(executor: Executor, runner: ProgramRunner[_ <: RunnerSettings]): ExecutionResult = {
+    val console = new ConsoleViewImpl(project, true)
+    val procHandler = new MProcHandler
+    console.attachToProcess(procHandler)
+    val bspCommunication = project.getComponent(classOf[BspCommunicationComponent]).communication
+
+    def notification(n: BspNotification): Unit = {
+      procHandler.notifyTextAvailable(n.toString, ProcessOutputType.STDOUT)
+    }
+
+    bspCommunication.run(testRequest, notification, procHandler.notifyTextAvailable(_, ProcessOutputType.STDOUT))
+      .future
+      .onComplete(_ => procHandler.shutdown())
+
+    new DefaultExecutionResult(console, procHandler)
+  }
+
+}

--- a/bsp/src/org/jetbrains/bsp/project/test/bspTestRunConfig.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/bspTestRunConfig.scala
@@ -1,0 +1,104 @@
+package org.jetbrains.bsp.project.test
+
+import java.io.OutputStream
+import java.net.URI
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+
+import ch.epfl.scala.bsp4j
+import ch.epfl.scala.bsp4j.TestResult
+import com.intellij.execution.configurations._
+import com.intellij.execution.impl.ConsoleViewImpl
+import com.intellij.execution.process.{ProcessHandler, ProcessOutputType}
+import com.intellij.execution.runners.{ExecutionEnvironment, ProgramRunner}
+import com.intellij.execution.{DefaultExecutionResult, ExecutionResult, Executor}
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.options.SettingsEditor
+import com.intellij.openapi.project.Project
+import javax.swing.{Icon, JComponent}
+import org.jetbrains.bsp.Icons
+import org.jetbrains.bsp.data.BspMetadata
+import org.jetbrains.bsp.protocol.BspCommunicationComponent
+import org.jetbrains.bsp.protocol.BspNotifications.BspNotification
+import org.jetbrains.bsp.protocol.session.BspSession.BspServer
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext.Implicits._
+
+
+class BspTestRunType extends ConfigurationType {
+  override def getDisplayName: String = "BSP test run"
+
+  override def getConfigurationTypeDescription: String = getDisplayName
+
+  override def getIcon: Icon = Icons.BSP
+
+  override def getId: String = "BSP_TEST_RUN_CONFIGURATION"
+
+  override def getConfigurationFactories: Array[ConfigurationFactory] = Array(new BspTestRunFactory(this))
+}
+
+class BspTestRunFactory(t: ConfigurationType) extends ConfigurationFactory(t) {
+  override def createTemplateConfiguration(project: Project): RunConfiguration = new BspTestRunConfiguration(project, this, "BSP_TEST_RUN")
+
+  override def getName: String = "BspTestRunFactory"
+}
+
+
+class BspTestRunConfiguration(val project: Project, val configurationFactory: ConfigurationFactory, val name: String)
+  extends RunConfigurationBase[String](project, configurationFactory, name) {
+  override def getConfigurationEditor: SettingsEditor[_ <: RunConfiguration] = new SettingsEditor[RunConfiguration]() {
+    override def resetEditorFrom(s: RunConfiguration): Unit = {}
+
+    override def applyEditorTo(s: RunConfiguration): Unit = {}
+
+    override def createEditor(): JComponent = new JComponent {}
+  }
+
+  private def targets(): List[URI] = {
+    val proj = getProject
+    ModuleManager.getInstance(proj).getModules.toList
+      .flatMap(BspMetadata.get(proj, _))
+      .flatMap(x => x.targetIds.asScala.toList)
+  }
+
+  private def testRequest(server: BspServer): CompletableFuture[TestResult] = {
+    val targetIds = targets().map(uri => new bsp4j.BuildTargetIdentifier(uri.toString))
+    val params = new bsp4j.TestParams(targetIds.toList.asJava)
+    params.setOriginId(UUID.randomUUID().toString)
+    server.buildTargetTest(params)
+  }
+
+  class MProcHandler extends ProcessHandler {
+    override def destroyProcessImpl(): Unit = ()
+
+    override def detachProcessImpl(): Unit = {}
+
+    override def detachIsDefault(): Boolean = false
+
+    override def getProcessInput: OutputStream = null
+
+    def shutdown(): Unit = {
+      super.notifyProcessTerminated(0)
+    }
+  }
+
+  override def getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState = new RunProfileState {
+    override def execute(executor: Executor, runner: ProgramRunner[_ <: RunnerSettings]): ExecutionResult = {
+      val console = new ConsoleViewImpl(getProject, true)
+      val procHandler = new MProcHandler
+      console.attachToProcess(procHandler)
+      val bspCommunication = project.getComponent(classOf[BspCommunicationComponent]).communication
+
+      def notification(n: BspNotification): Unit = {
+        procHandler.notifyTextAvailable(n.toString, ProcessOutputType.STDOUT)
+      }
+
+      bspCommunication.run(testRequest, notification, procHandler.notifyTextAvailable(_, ProcessOutputType.STDOUT))
+        .future
+        .onComplete(_ => procHandler.shutdown())
+
+      new DefaultExecutionResult(console, procHandler)
+    }
+  }
+}

--- a/bsp/src/org/jetbrains/bsp/project/test/bspTestRunConfig.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/bspTestRunConfig.scala
@@ -1,29 +1,13 @@
 package org.jetbrains.bsp.project.test
 
-import java.io.OutputStream
-import java.net.URI
-import java.util.UUID
-import java.util.concurrent.CompletableFuture
-
-import ch.epfl.scala.bsp4j
-import ch.epfl.scala.bsp4j.TestResult
+import com.intellij.execution.Executor
 import com.intellij.execution.configurations._
-import com.intellij.execution.impl.ConsoleViewImpl
-import com.intellij.execution.process.{ProcessHandler, ProcessOutputType}
-import com.intellij.execution.runners.{ExecutionEnvironment, ProgramRunner}
-import com.intellij.execution.{DefaultExecutionResult, ExecutionResult, Executor}
-import com.intellij.openapi.module.ModuleManager
+import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
 import javax.swing.{Icon, JComponent}
 import org.jetbrains.bsp.Icons
-import org.jetbrains.bsp.data.BspMetadata
-import org.jetbrains.bsp.protocol.BspCommunicationComponent
-import org.jetbrains.bsp.protocol.BspNotifications.BspNotification
-import org.jetbrains.bsp.protocol.session.BspSession.BspServer
 
-import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext.Implicits._
 
 
 class BspTestRunType extends ConfigurationType {
@@ -52,53 +36,9 @@ class BspTestRunConfiguration(val project: Project, val configurationFactory: Co
 
     override def applyEditorTo(s: RunConfiguration): Unit = {}
 
+    //TODO create editor
     override def createEditor(): JComponent = new JComponent {}
   }
 
-  private def targets(): List[URI] = {
-    val proj = getProject
-    ModuleManager.getInstance(proj).getModules.toList
-      .flatMap(BspMetadata.get(proj, _))
-      .flatMap(x => x.targetIds.asScala.toList)
-  }
-
-  private def testRequest(server: BspServer): CompletableFuture[TestResult] = {
-    val targetIds = targets().map(uri => new bsp4j.BuildTargetIdentifier(uri.toString))
-    val params = new bsp4j.TestParams(targetIds.toList.asJava)
-    params.setOriginId(UUID.randomUUID().toString)
-    server.buildTargetTest(params)
-  }
-
-  class MProcHandler extends ProcessHandler {
-    override def destroyProcessImpl(): Unit = ()
-
-    override def detachProcessImpl(): Unit = {}
-
-    override def detachIsDefault(): Boolean = false
-
-    override def getProcessInput: OutputStream = null
-
-    def shutdown(): Unit = {
-      super.notifyProcessTerminated(0)
-    }
-  }
-
-  override def getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState = new RunProfileState {
-    override def execute(executor: Executor, runner: ProgramRunner[_ <: RunnerSettings]): ExecutionResult = {
-      val console = new ConsoleViewImpl(getProject, true)
-      val procHandler = new MProcHandler
-      console.attachToProcess(procHandler)
-      val bspCommunication = project.getComponent(classOf[BspCommunicationComponent]).communication
-
-      def notification(n: BspNotification): Unit = {
-        procHandler.notifyTextAvailable(n.toString, ProcessOutputType.STDOUT)
-      }
-
-      bspCommunication.run(testRequest, notification, procHandler.notifyTextAvailable(_, ProcessOutputType.STDOUT))
-        .future
-        .onComplete(_ => procHandler.shutdown())
-
-      new DefaultExecutionResult(console, procHandler)
-    }
-  }
+  override def getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState = new BspTestRunProfileState(getProject)
 }

--- a/bsp/src/org/jetbrains/bsp/project/test/bspTestRunConfig.scala
+++ b/bsp/src/org/jetbrains/bsp/project/test/bspTestRunConfig.scala
@@ -40,5 +40,5 @@ class BspTestRunConfiguration(val project: Project, val configurationFactory: Co
     override def createEditor(): JComponent = new JComponent {}
   }
 
-  override def getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState = new BspTestRunProfileState(getProject)
+  override def getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState = new BspTestRunProfileState(getProject, this, executor)
 }


### PR DESCRIPTION
I ended up faking the ProcessHandler class as if there's a running process underneath.

Some issues that deserve attention
- not sure if I am using `MProcHandler` correctly. 
- I use `import scala.concurrent.ExecutionContext.Implicits._` for passing the execution context in `bspCommunication.run .. onComplete`. Is this correct ?
- I am not sure if an exception will be raised if UI elements are modified from non-main thread. I tried to read the implementation of ConsoleView, and seems like it uses queue to flush the output  in main thread. I am not 100% sure that this class is thread safe though.
- My usage of APIs for running a runconfig seems weird. So please tell me if `getState` method is sensible.  